### PR TITLE
feat(push): add proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Python cache files
+__pycache__/
+*.pyc
+
+# Log files
+logs/
+*.log

--- a/README.md
+++ b/README.md
@@ -76,6 +76,30 @@
 
 意思为：【在每天两点时刻使用python所在位置编译器运行某个路径下的`main.py`脚本，同时将输出按每天的日期格式输出到对应日志中】可供参考）。
 
+## 代理配置说明 🌐
+
+如果你需要使用代理来确保消息推送的可靠性（特别是使用 Telegram 推送时），可以通过以下方式配置：
+
+### 本地运行时：
+在系统中设置环境变量：
+```bash
+export http_proxy=http://127.0.0.1:7890
+export https_proxy=http://127.0.0.1:7890
+```
+
+### 使用 crontab 运行时：
+在 crontab 命令前添加代理设置：
+```bash
+30 0 * * * http_proxy=http://127.0.0.1:7890 https_proxy=http://127.0.0.1:7890 /usr/bin/python3 /path/to/your/main.py >> /path/to/logs/$(date +\%y-\%m.\%d)_sout.log 2>&1
+```
+
+### GitHub Actions 中：
+在仓库的 Secrets 中添加：
+- `http_proxy`: 你的 HTTP 代理地址
+- `https_proxy`: 你的 HTTPS 代理地址
+
+然后在 workflow 文件中使用这些环境变量。
+
 ***
 ## 字段解释 🔍
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/815aaec6-b775-4572-b0b4-a0cc48eb7844)

在 crontab 中，无法使用当前终端的代理配置，会导致 telegram 的 push 失败，增加此配置后，在环境变量中设置 proxies，即可成功 push 到 telegram

![image](https://github.com/user-attachments/assets/813296e3-df46-43f7-9952-abcb3876fb91)
