### PR TITLE
添加 workflow 保活作业

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,10 +49,12 @@ jobs:
 
       run: |
         python main.py
-  workflow-keepalive:
-    if: github.event_name == 'schedule'
+        
+  keepalive-job:
+    name: Keepalive Workflow
     runs-on: ubuntu-latest
     permissions:
       actions: write
     steps:
-      - uses: liskin/gh-workflow-keepalive@v1
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,3 +49,10 @@ jobs:
 
       run: |
         python main.py
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1


### PR DESCRIPTION
如果仓库在过去 60 天内没有任何提交，GitHub 将暂停 GitHub 操作工作流的计划触发器。除非有新的提交，否则基于 cron 的触发器将不会运行。在 cronjob 触发的操作下会显示消息“此计划工作流已被禁用，因为此仓库至少 60 天内没有任何活动”。
-- [keepalive-workflow](https://github.com/marketplace/actions/keepalive-workflow)