### PR TITLE
Add concurrency to deploy workflow to cancel in-progress runs.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,9 @@
 name: wxread
 
+concurrency:
+  group: ${{ github.workflow }} # 使用工作流名称作为并发组的key
+  cancel-in-progress: true    # 取消任何正在进行的相同并发组的工作流
+
 on:
   schedule:
     # 凌晨任务：北京时间每天 01:00（UTC 前一天 17:00）
@@ -49,7 +53,7 @@ jobs:
 
       run: |
         python main.py
-        
+
   keepalive-job:
     name: Keepalive Workflow
     if: ${{ always() }}


### PR DESCRIPTION
feat: Add concurrency to deploy workflow to prevent overlapping runs

This pull request introduces a concurrency configuration to the `wxread` deployment workflow. The primary motivation is to prevent multiple instances of the same workflow from running simultaneously, which can lead to resource contention, data inconsistencies, or unnecessary processing.

For a scheduled job like `wxread`, it's crucial to ensure that only one instance is active at any given time. If a previous run is still processing when a new scheduled run begins (e.g., due to a long-running task or a delay), this configuration will automatically cancel the older, in-progress run in favor of the newer one. This helps maintain the integrity of the deployment process and ensures that only the most recent scheduled execution is completed.

Close #89

**Changes:**

* Added a `concurrency` block to the `.github/workflows/deploy.yml` workflow.
* Configured the `group` property to use the workflow's name (`${{ github.workflow }}`) for concurrency grouping.
* Set `cancel-in-progress: true` to automatically cancel any ongoing workflow runs within the same group when a new one is triggered.
