### PR TITLE
微信读书似乎对renewal 接口增加了额外的验证

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,8 @@ jobs:
         TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
         TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         SERVERCHAN_SPT:  ${{ secrets.SERVERCHAN_SPT }}
+        GOTIFY_URL: ${{ secrets.GOTIFY_URL }}
+        GOTIFY_TOKEN: ${{ secrets.GOTIFY_TOKEN }}
         READ_NUM: ${{ vars.READ_NUM }}  # 使用 Repository Variables
 
       run: |

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@
 
 - Fork这个仓库，在仓库 **Settings** -> 左侧列表中的 **Secrets and variables** -> **Actions**，然后在右侧的 **Repository secrets** 中添加如下值：
   - `WXREAD_CURL_BASH`：上面抓read接口后转换为curl_bash的数据。
-  - `PUSH_METHOD`：推送方法，4选1推送方式（pushplus、wxpusher、telegram、serverChan）。
-  - `PUSHPLUS_TOKEN` or `WXPUSHER_SPT` or `TELEGRAM_BOT_TOKEN`&`TELEGRAM_CHAT_ID` or `SERVERCHAN_SPT`: 选择推送后填写对应token。
+  - `PUSH_METHOD`：推送方法，5选1推送方式（pushplus、wxpusher、telegram、serverChan、gotify）。
+  - `PUSHPLUS_TOKEN` or `WXPUSHER_SPT` or `TELEGRAM_BOT_TOKEN`&`TELEGRAM_CHAT_ID` or `SERVERCHAN_SPT` or `GOTIFY_URL`&`GOTIFY_TOKEN`: 选择推送后填写对应token。
   
 - 在 **Variables** 部分，最下方添加变量：
   - `READ_NUM`：设定每次阅读的目标次数。
@@ -44,11 +44,12 @@
 | ------------------------- | ---------------------------------- | ------------------------------------------------------------ | --------- |
 | `WXREAD_CURL_BASH`         | `read` 接口 `curl_bash`数据 | **必填**，必须提供有效指令                                   | secrets   |
 | `READ_NUM`                 | 阅读次数（每次 30 秒）              | **可选**，阅读时长，默认 20 分钟                           | variables |
-| `PUSH_METHOD`              | `pushplus`/`wxpusher`/`telegram`/`serverchan`    | **可选**，推送方式，4选1，默认不推送                                       |    secrets     |
+| `PUSH_METHOD`              | `pushplus`/`wxpusher`/`telegram`/`serverchan`/`gotify`    | **可选**，推送方式，5选1，默认不推送                                       |    secrets     |
 | `PUSHPLUS_TOKEN`           | PushPlus 的 token                   | 当 `PUSH_METHOD=pushplus` 时必填，[获取地址](https://www.pushplus.plus/uc.html) | secrets   |
 | `WXPUSHER_SPT`             | WxPusher 的token                    | 当 `PUSH_METHOD=wxpusher` 时必填，[获取地址](https://wxpusher.zjiecode.com/docs/#/?id=获取spt) | secrets   |
 | `TELEGRAM_BOT_TOKEN`  <br>`TELEGRAM_CHAT_ID`   <br>`http_proxy`/`https_proxy`（可选）| 群组id以及机器人token                 | 当 `PUSH_METHOD=telegram` 时必填，[配置文档](https://www.nodeseek.com/post-22475-1) | secrets   |
 | `SERVERCHAN_SPT`          | serverchan 的 SendKey               | 当 `PUSH_METHOD=serverchan` 时必填，[获取地址](https://sct.ftqq.com/sendkey) | secrets   |
+| `GOTIFY_URL`  <br>`GOTIFY_TOKEN`  | Gotify 的服务器地址和应用token         | 当 `PUSH_METHOD=gotify` 时必填，[获取地址](https://gotify.net/docs/pushmsg) | secrets   |
 
 **重要：除了READ_NUM配置在varables，其它的都配置在secrets里面的；需要推送`PUSH_METHOD`是必填的。**
 

--- a/config.py
+++ b/config.py
@@ -20,6 +20,9 @@ TELEGRAM_CHAT_ID = "" or os.getenv("TELEGRAM_CHAT_ID")
 WXPUSHER_SPT = "" or os.getenv("WXPUSHER_SPT")
 # SeverChan推送时需填
 SERVERCHAN_SPT = "" or os.getenv("SERVERCHAN_SPT")
+# Gotify推送时需填
+GOTIFY_URL = "" or os.getenv("GOTIFY_URL")
+GOTIFY_TOKEN = "" or os.getenv("GOTIFY_TOKEN")
 
 
 # read接口的bash命令，本地部署时可对应替换headers、cookies


### PR DESCRIPTION
今天新增加了gotify推送方式后发现无法更新cookie了，换浏览器、重新登录都无法获取新的cookie，删除项目重新fork还是一样，看了下返回信息，微信读书似乎对renewal 接口增加了额外的验证，read 接口直接请求是成功的 ，但 renewal 接口鉴权失败 。稍微修改了一下：

main.py 的修改：
新增 test_cookie_valid() 函数

使用 read 接口直接测试 cookie 是否有效
绕过 renewal 接口的鉴权问题
修改 refresh_cookie() 函数

先尝试 renewal 接口
如果失败，再测试 read 接口
只要有一个成功，就继续阅读
修改初始验证逻辑

启动时先用 test_cookie_valid() 测试 cookie
如果有效，直接开始阅读
如果无效，再尝试刷新
修复编码问题

所有 requests.post 的数据都使用 .encode('utf-8')
避免中文编码错误
添加超时设置

防止请求卡住