### PR TITLE
fix: 修复 get_wr_skey 鉴权失败时未继续尝试其他参数的问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ def refresh_cookie():
     new_skey = get_wr_skey()
     if new_skey:
         cookies['wr_skey'] = new_skey
-        logging.info(f"密钥刷新成功，新密钥：{new_skey}")
+        logging.info(f"密钥刷新成功，新密钥：{new_skey[:2]}***")
         logging.info("重新本次阅读。")
     else:
         ERROR_CODE = "无法获取新密钥或者 WXREAD_CURL_BASH 配置有误，终止运行。"

--- a/main.py
+++ b/main.py
@@ -43,20 +43,19 @@ def get_wr_skey():
     for cookie_data in COOKIE_DATA_VARIANTS:
         try:
             response = requests.post(RENEW_URL,headers=headers,cookies=cookies,data=json.dumps(cookie_data, separators=(',', ':')),timeout=10)
+            
+            logging.info(response.json())
+            logging.info(response.cookies)
+            
+            if 'wr_skey' in response.cookies:
+                return response.cookies['wr_skey'][:8]
+            else:
+                continue
         except requests.RequestException as exc:
             logging.warning(f"refresh_cookie 请求失败，payload={cookie_data}，原因：{exc}")
             continue
         
-        logging.info(response.json())
-        logging.info(response.cookies)
-        logging.info(response.raw)
-        # 优先从 response.cookies 获取（requests 自动解析 Set-Cookie）
-        if 'wr_skey' in response.cookies:
-            return response.cookies['wr_skey'][:8]
-
-        for cookie in response.headers.get('Set-Cookie', '').split(';'):
-            if "wr_skey" in cookie:
-                return cookie.split('=')[-1][:8]
+        
     return None
 
 def fix_no_synckey():

--- a/main.py
+++ b/main.py
@@ -46,7 +46,8 @@ def get_wr_skey():
         except requests.RequestException as exc:
             logging.warning(f"refresh_cookie 请求失败，payload={cookie_data}，原因：{exc}")
             continue
-
+        
+        logging.info(response)
         # 优先从 response.cookies 获取（requests 自动解析 Set-Cookie）
         if 'wr_skey' in response.cookies:
             return response.cookies['wr_skey'][:8]

--- a/main.py
+++ b/main.py
@@ -44,9 +44,6 @@ def get_wr_skey():
         try:
             response = requests.post(RENEW_URL,headers=headers,cookies=cookies,data=json.dumps(cookie_data, separators=(',', ':')),timeout=10)
             
-            logging.info(response.json())
-            logging.info(response.cookies)
-            
             if 'wr_skey' in response.cookies:
                 return response.cookies['wr_skey'][:8]
             else:

--- a/main.py
+++ b/main.py
@@ -47,6 +47,10 @@ def get_wr_skey():
             logging.warning(f"refresh_cookie 请求失败，payload={cookie_data}，原因：{exc}")
             continue
 
+        # 优先从 response.cookies 获取（requests 自动解析 Set-Cookie）
+        if 'wr_skey' in response.cookies:
+            return response.cookies['wr_skey'][:8]
+
         for cookie in response.headers.get('Set-Cookie', '').split(';'):
             if "wr_skey" in cookie:
                 return cookie.split('=')[-1][:8]

--- a/main.py
+++ b/main.py
@@ -47,7 +47,9 @@ def get_wr_skey():
             logging.warning(f"refresh_cookie 请求失败，payload={cookie_data}，原因：{exc}")
             continue
         
-        logging.info(response)
+        logging.info(response.json())
+        logging.info(response.cookies)
+        logging.info(response.raw)
         # 优先从 response.cookies 获取（requests 自动解析 Set-Cookie）
         if 'wr_skey' in response.cookies:
             return response.cookies['wr_skey'][:8]


### PR DESCRIPTION
### 问题

`get_wr_skey()` 函数遍历 `COOKIE_DATA_VARIANTS` 列表，依次尝试 `ql` 的三种取值来刷新 `wr_skey`。但当鉴权失败时，renewal 接口返回 **HTTP 200**，响应体为：

```json
{"errCode": -2013, "errLog": "****", "errMsg": "鉴权失败"}
```

由于 HTTP 状态码为 200，不会触发 `requests.RequestException`，因此 `except` 分支中的 `continue` 永远不会执行。当 `response.cookies` 中不存在 `wr_skey` 时，函数直接返回 `None`，**剩余的参数变体根本不会被尝试**，导致 3 次循环实际只执行了 1 次。

### 修复

在 `response.cookies` 中未找到 `wr_skey` 时，显式 `continue` 继续尝试下一个参数变体，确保所有 `COOKIE_DATA_VARIANTS` 都有机会被测试。

另外：log信息中隐藏wr_skey新密钥的部分字符以增强安全性（action日志是公开可见）