### PR TITLE
fix: pushplus通知 添加成功与失败状态的标题

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,7 +67,7 @@ def refresh_cookie():
     else:
         ERROR_CODE = "无法获取新密钥或者 WXREAD_CURL_BASH 配置有误，终止运行。"
         logging.error(ERROR_CODE)
-        push(ERROR_CODE, PUSH_METHOD)
+        push(ERROR_CODE, PUSH_METHOD, is_success=False)
         raise Exception(ERROR_CODE)
 
 refresh_cookie()
@@ -110,6 +110,6 @@ logging.info("阅读脚本已完成。")
 
 if PUSH_METHOD not in (None, ''):
     logging.info("开始推送...")
-    push(f"微信读书自动阅读完成。\n阅读时长：{(index - 1) * 0.5} 分钟。", PUSH_METHOD)
+    push(f"微信读书自动阅读完成。\n阅读时长：{(index - 1) * 0.5} 分钟。", PUSH_METHOD, is_success=True)
 else:
     logging.info("未配置推送渠道，跳过推送。")

--- a/push.py
+++ b/push.py
@@ -29,13 +29,14 @@ class PushNotification:
             "https": os.getenv("https_proxy"),
         }
 
-    def push_pushplus(self, content, token):
+    def push_pushplus(self, content, token, is_success):
         attempts = 5
+        title = f"微信阅读-{'成功' if is_success else '失败'}"
         for attempt in range(attempts):
             try:
                 response = requests.post(
                     self.pushplus_url,
-                    data=json.dumps({"token": token, "title": "微信阅读推送","content": content,}).encode("utf-8"),headers=self.headers,timeout=10,)
+                    data=json.dumps({"token": token, "title": title,"content": content,}).encode("utf-8"),headers=self.headers,timeout=10,)
                 response.raise_for_status()
                 logger.info("PushPlus 响应: %s", response.text)
                 return True
@@ -84,13 +85,11 @@ class PushNotification:
                     time.sleep(sleep_time)
         return False
 
-    def push_serverChan(self, content, spt):
+    def push_serverChan(self, content, spt, is_success):
         attempts = 5
         url = self.server_chan_url.format(spt)
 
-        title = "微信阅读推送"
-        if "自动阅读完成" not in content:
-            title = "微信阅读失败"
+        title = f"微信阅读-{'成功' if is_success else '失败'}"
 
         for attempt in range(attempts):
             try:
@@ -112,7 +111,7 @@ class PushNotification:
         return False
 
 
-def push(content, method):
+def push(content, method, is_success = True):
     notifier = PushNotification()
 
     if method in (None, ""):
@@ -122,13 +121,13 @@ def push(content, method):
     method = str(method).lower()
 
     if method == "pushplus":
-        return notifier.push_pushplus(content, PUSHPLUS_TOKEN)
+        return notifier.push_pushplus(content, PUSHPLUS_TOKEN, is_success)
     if method == "telegram":
         return notifier.push_telegram(content, TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID)
     if method == "wxpusher":
         return notifier.push_wxpusher(content, WXPUSHER_SPT)
     if method == "serverchan":
-        return notifier.push_serverChan(content, SERVERCHAN_SPT)
+        return notifier.push_serverChan(content, SERVERCHAN_SPT, is_success)
 
     logger.warning("无效的通知渠道 '%s'，已跳过推送。支持：pushplus、telegram、wxpusher、serverchan", method)
     return False


### PR DESCRIPTION
pushplus通知标题中不显示执行成功/失败的状态信息，需要点进详情中才能看到，不方便。

本次修改在pushplus通知标题中添加 成功/失败的状态信息

同时优化了push_serverChan通知的成功、失败的判断逻辑，不再强依赖于文案内容

<img width="425" height="228" alt="image" src="https://github.com/user-attachments/assets/b27dcaa8-9205-47d5-819d-3226289940cb" />
